### PR TITLE
Minor changes to get the new FD-DAQ nightly build to run

### DIFF
--- a/plugins/FDDataLinkHandler.cpp
+++ b/plugins/FDDataLinkHandler.cpp
@@ -96,7 +96,7 @@ FDDataLinkHandler::get_info(opmonlib::InfoCollector& ci, int level)
 }
 
 std::unique_ptr<readoutlibs::ReadoutConcept>
-FDDataLinkHandlercreate_readout(const nlohmann::json& args, std::atomic<bool>& run_marker)
+FDDataLinkHandler::create_readout(const nlohmann::json& args, std::atomic<bool>& run_marker)
 {
   namespace rol = dunedaq::readoutlibs;
   namespace fdl = dunedaq::fdreadoutlibs;

--- a/plugins/FDDataLinkHandler.hpp
+++ b/plugins/FDDataLinkHandler.hpp
@@ -21,7 +21,7 @@ namespace dunedaq {
 namespace fdreadoutmodules {
 
 class FDDataLinkHandler : public dunedaq::appfwk::DAQModule,
-                          private dunedaq::readoutmodules::DataLinkHandlerBase
+                          public dunedaq::readoutmodules::DataLinkHandlerBase
 {
 public:
   using inherited_dlh = dunedaq::readoutmodules::DataLinkHandlerBase;

--- a/plugins/FDFakeCardReader.hpp
+++ b/plugins/FDFakeCardReader.hpp
@@ -21,7 +21,7 @@ namespace dunedaq {
 namespace fdreadoutmodules {
 
 class FDFakeCardReader : public dunedaq::appfwk::DAQModule,
-                         private dunedaq::readoutmodules::FakeCardReaderBase
+                         public dunedaq::readoutmodules::FakeCardReaderBase
 {
 public:
   using inherited_fcr = dunedaq::readoutmodules::FakeCardReaderBase;

--- a/pybindsrc/pythonbindingsrenameme.cpp
+++ b/pybindsrc/pythonbindingsrenameme.cpp
@@ -17,7 +17,7 @@ namespace py = pybind11;
 namespace dunedaq::fdreadoutmodules::python {
 
 void
-register_renameme(py::module& m)
+register_renameme(py::module& /*the_module*/)
 {}
 
 } // namespace dunedaq::fdreadoutmodules::python


### PR DESCRIPTION
These changes were of three types:

- the fixing of a typo in the definition of the FDDataLinkHandler::create_readout() method (the double-colon was omitted)
- the change of private inheritance to public inheritance for FakeCardReaderBase and DataLinkHandlerBase
- the commenting out of an unused method argument in the python binding so quiet a compiler warning

The first and third will likely not cause any objections.

I'm not sure the if the change from private to public inheritance will generate any objections, though.  Was the choice of private inheritance an important part of the design?  If so, then probably we should talk about that choice and the crashes that I saw.

Here is the crash dump.  The line that it fails on is one that accesses m_configured in the base class.

```
2023-Jun-20 08:29:31,791 ERROR [static void ers::ErrorHandler::SignalHandler::action(int, siginfo_t*, void*) at /tmp/root/spack-stage/spack-stage-ers-NB23-06-20-q5k4eevyskvvweems37kryt5geoooxs2/spack-src/src/ErrorHandler.cpp:90] Got signal 11 Segmentation fault (invalid memory reference)
	Parameters = 'name=Segmentation fault (invalid memory reference)' 'signum=11' 
	Qualifiers = 'unknown' 
	host = mu2edaq13
	user = biery (2310)
	process id = 2885
	thread id = 2898
	process wd = /tmp/pytest-of-biery/pytest-214/run0
	stack trace of the crashing thread:
	  #0  /home/biery/dunedaq/20JunFDDev/install/fdreadoutmodules/lib64/libfdreadoutmodules_FDFakeCardReader_duneDAQModule.so(dunedaq::readoutmodules::FakeCardReaderBase::do_conf(nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > const&)+0x4a3) [0x7efdb7143653]
	  #1  /lib64/libpthread.so.0(+0xf630) [0x7efdeadde630]
	  #2  /home/biery/dunedaq/20JunFDDev/install/fdreadoutmodules/lib64/libfdreadoutmodules_FDFakeCardReader_duneDAQModule.so(dunedaq::readoutmodules::FakeCardReaderBase::do_conf(nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > const&)+0x4a3) [0x7efdb7143653]
	  #3  daq_application() [0x43c060]
	  #4  daq_application() [0x43d183]
	  #5  daq_application() [0x43d401]
	  #6  /cvmfs/dunedaq-development.opensciencegrid.org/nightly/NB23-06-20/spack-0.18.1-gcc-12.1.0/spack-0.18.1/opt/spack/gcc-12.1.0/cmdlib-NB23-06-20-rajdqrxcpanyjr5szlz5micxb3gljoyy/lib64/libcmdlib.so(dunedaq::cmdlib::CommandFacility::handle_command(nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > const&, dunedaq::cmdlib::cmd::CommandReply)+0x27) [0x7efdeb7e8c17]
	  #7  /cvmfs/dunedaq-development.opensciencegrid.org/nightly/NB23-06-20/spack-0.18.1-gcc-12.1.0/spack-0.18.1/opt/spack/gcc-12.1.0/cmdlib-NB23-06-20-rajdqrxcpanyjr5szlz5micxb3gljoyy/lib64/libcmdlib.so(std::_Function_handler<void (nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > const&, dunedaq::cmdlib::cmd::CommandReply), std::_Bind<void (dunedaq::cmdlib::CommandFacility::*(dunedaq::cmdlib::CommandFacility*, std::_Placeholder<1>, std::_Placeholder<2>))(nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > const&, dunedaq::cmdlib::cmd::CommandReply)> >::_M_invoke(std::_Any_data const&, nlohmann::basic_json<std::map, std::vector, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, long, unsigned long, double, std::allocator, nlohmann::adl_serializer, std::vector<unsigned char, std::allocator<unsigned char> > > const&, dunedaq::cmdlib::cmd::CommandReply&&)+0xea) [0x7efdeb7f667a]
...
```