### PR TITLE
Add NUMA Definitions & Version Update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-cmake/
 
 cmake_minimum_required(VERSION 3.12)
-project(fdreadoutmodules VERSION 1.0.3)
+project(fdreadoutmodules VERSION 1.0.4)
 
 find_package(daq-cmake REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,16 @@ set(FDREADOUTLIBS_USE_INTRINSICS ON)
 if(${FDREADOUTLIBS_USE_INTRINSICS})
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")
 endif()
+
+set(READOUT_USE_LIBNUMA ON)
+
+if(${READOUT_USE_LIBNUMA})
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(numa REQUIRED IMPORTED_TARGET "numa")
+  list(APPEND READOUT_DEPENDENCIES numa)
+  #list(APPEND READOUT_DEPENDENCIES ${numa_LINK_LIBRARIES})
+  add_compile_definitions(WITH_LIBNUMA_SUPPORT WITH_LIBNUMA_BIND_POLICY=1 WITH_LIBNUMA_STRICT_POLICY=1)
+endif()
 ##############################################################################
 
 


### PR DESCRIPTION
This adds `libnuma` definitions that are used by [readoutlibs](https://github.com/DUNE-DAQ/readoutlibs). Without these definitions, `readoutlibs` does not compile with NUMA support.

This change was tested on NP02 on a NUMA targeting configuration. Before applying this branch, the `conf` stage would result in an error that complains about missing NUMA support. After, the `conf` stage would pass. Additional debug TLOGs were used to track the progress and found that everything worked as expected.

This also include a patch version update from v1.0.3 to v1.0.4.