### PR TITLE
FDFakeCardReader emulator sources parameters fixed

### DIFF
--- a/plugins/FDDataHandlerModule.cpp
+++ b/plugins/FDDataHandlerModule.cpp
@@ -97,10 +97,13 @@ FDDataHandlerModule::create_readout(const appmodel::DataHandlerModule* modconf, 
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for an Ethernet DUNE-WIB";
     auto readout_model = std::make_shared<
       rol::DataHandlingModel<fdt::DUNEWIBEthTypeAdapter,
-			     rol::ZeroCopyRecordingRequestHandlerModel<fdt::DUNEWIBEthTypeAdapter,
-								       rol::FixedRateQueueModel<fdt::DUNEWIBEthTypeAdapter>>,
-			     rol::FixedRateQueueModel<fdt::DUNEWIBEthTypeAdapter>,
-			     fdl::WIBEthFrameProcessor>>(run_marker);
+      rol::ZeroCopyRecordingRequestHandlerModel<
+        fdt::DUNEWIBEthTypeAdapter,
+        rol::FixedRateQueueModel<fdt::DUNEWIBEthTypeAdapter>
+      >,
+      rol::FixedRateQueueModel<fdt::DUNEWIBEthTypeAdapter>,
+      fdl::WIBEthFrameProcessor
+      >>(run_marker);
     register_node("WIBEthFrameProcessor", readout_model);
     readout_model->init(modconf);
     return readout_model;
@@ -110,12 +113,16 @@ FDDataHandlerModule::create_readout(const appmodel::DataHandlerModule* modconf, 
   if (raw_dt.find("TDEEthFrame") != std::string::npos) {
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for an Ethernet TDEEth";
     auto readout_model = 
-      std::make_unique<rol::DataHandlingModel<
+      std::make_shared<rol::DataHandlingModel<
         fdt::TDEEthTypeAdapter,
-        rol::ZeroCopyRecordingRequestHandlerModel<fdt::TDEEthTypeAdapter, rol::FixedRateQueueModel<fdt::TDEEthTypeAdapter>>,
+        rol::ZeroCopyRecordingRequestHandlerModel<
+          fdt::TDEEthTypeAdapter,
+          rol::FixedRateQueueModel<fdt::TDEEthTypeAdapter>
+        >,
         rol::FixedRateQueueModel<fdt::TDEEthTypeAdapter>,
         fdl::TDEEthFrameProcessor
       >>(run_marker);
+    register_node("TDEEthFrameProcessor", readout_model);
     readout_model->init(modconf);
     return readout_model;
   }
@@ -139,7 +146,7 @@ FDDataHandlerModule::create_readout(const appmodel::DataHandlerModule* modconf, 
     auto readout_model = std::make_shared<
       rol::DataHandlingModel<fdt::DAPHNEStreamSuperChunkTypeAdapter,
                         rol::DefaultRequestHandlerModel<fdt::DAPHNEStreamSuperChunkTypeAdapter,
-                                                        rol::BinarySearchQueueModel<fdt::DAPHNEStreamSuperChunkTypeAdapter>>,
+                        rol::BinarySearchQueueModel<fdt::DAPHNEStreamSuperChunkTypeAdapter>>,
                         rol::BinarySearchQueueModel<fdt::DAPHNEStreamSuperChunkTypeAdapter>,
                         fdl::DAPHNEStreamFrameProcessor>>(run_marker);
     register_node("PDSStreamFrameProcessor", readout_model);

--- a/plugins/FDFakeReaderModule.cpp
+++ b/plugins/FDFakeReaderModule.cpp
@@ -70,9 +70,9 @@ FDFakeReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>& 
 {
   //! Values suitable to emulation
 
-  static constexpr int daphnestream_time_tick_diff = 16;
-  static constexpr double daphnestream_dropout_rate = 0.9;
-  static constexpr double daphnestream_rate_khz = 200.0;
+  static constexpr int daphnestream_time_tick_diff = fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter::expected_tick_difference;
+  static constexpr double daphnestream_dropout_rate = 0.0;
+  static constexpr double daphnestream_rate_khz = 62500./daphnestream_time_tick_diff/fdreadoutlibs::types::kDAPHNEStreamNumFrames;
   static constexpr int daphnestream_frames_per_tick = 1;
 
   static constexpr int wibeth_time_tick_diff = fdreadoutlibs::types::DUNEWIBEthTypeAdapter::expected_tick_difference;;

--- a/plugins/FDFakeReaderModule.cpp
+++ b/plugins/FDFakeReaderModule.cpp
@@ -70,20 +70,20 @@ FDFakeReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>& 
 {
   //! Values suitable to emulation
 
-  static constexpr int daphne_time_tick_diff = 16;
-  static constexpr double daphne_dropout_rate = 0.9;
-  static constexpr double daphne_rate_khz = 200.0;
-  static constexpr int daphne_frames_per_tick = 1;
+  static constexpr int daphnestream_time_tick_diff = 16;
+  static constexpr double daphnestream_dropout_rate = 0.9;
+  static constexpr double daphnestream_rate_khz = 200.0;
+  static constexpr int daphnestream_frames_per_tick = 1;
 
-  static constexpr int wibeth_time_tick_diff = 32*64;
+  static constexpr int wibeth_time_tick_diff = fdreadoutlibs::types::DUNEWIBEthTypeAdapter::expected_tick_difference;;
   static constexpr double wibeth_dropout_rate = 0.0;
-  static constexpr double wibeth_rate_khz = 30.5176;
+  static constexpr double wibeth_rate_khz = 62500./wibeth_time_tick_diff;
   static constexpr int wibeth_frames_per_tick = 1;
 
-  static constexpr int tde_time_tick_diff = dunedaq::fddetdataformats::ticks_between_adc_samples*dunedaq::fddetdataformats::tot_adc16_samples;
-  static constexpr double tde_dropout_rate = 0.0;
-  static constexpr double tde_rate_khz = 62500./tde_time_tick_diff;
-  static constexpr int tde_frames_per_tick = dunedaq::fddetdataformats::n_channels_per_amc;
+  static constexpr int tdeeth_time_tick_diff = fdreadoutlibs::types::TDEEthTypeAdapter::expected_tick_difference;
+  static constexpr double tdeeth_dropout_rate = 0.0;
+  static constexpr double tdeeth_rate_khz = 62500./tdeeth_time_tick_diff;
+  static constexpr int tdeeth_frames_per_tick = 1;
 
   static constexpr double emu_frame_error_rate = 0.0;
 
@@ -111,7 +111,7 @@ FDFakeReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>& 
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake pds link";
     auto source_emu_model =
       std::make_shared<datahandlinglibs::SourceEmulatorModel<fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>>(
-        q_id, run_marker, daphne_time_tick_diff, daphne_dropout_rate, emu_frame_error_rate, daphne_rate_khz, daphne_frames_per_tick);
+        q_id, run_marker, daphnestream_time_tick_diff, daphnestream_dropout_rate, emu_frame_error_rate, daphnestream_rate_khz, daphnestream_frames_per_tick);
       register_node(q_id, source_emu_model);
       return source_emu_model;
   }
@@ -121,17 +121,7 @@ FDFakeReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>& 
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake pds stream link";
     auto source_emu_model =
       std::make_shared<datahandlinglibs::SourceEmulatorModel<fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>>(
-        q_id, run_marker, daphne_time_tick_diff, daphne_dropout_rate, emu_frame_error_rate, daphne_rate_khz, daphne_frames_per_tick);
-      register_node(q_id, source_emu_model);
-    return source_emu_model;
-  }
-
-  // IF TDE
-  if (raw_dt.find("TDEFrame") != std::string::npos) {
-    TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake tde link";
-    auto source_emu_model =
-      std::make_shared<datahandlinglibs::SourceEmulatorModel<fdreadoutlibs::types::TDEFrameTypeAdapter>>(
-        q_id, run_marker, tde_time_tick_diff, tde_dropout_rate, emu_frame_error_rate, tde_rate_khz, tde_frames_per_tick);
+        q_id, run_marker, daphnestream_time_tick_diff, daphnestream_dropout_rate, emu_frame_error_rate, daphnestream_rate_khz, daphnestream_frames_per_tick);
       register_node(q_id, source_emu_model);
     return source_emu_model;
   }
@@ -143,11 +133,11 @@ FDFakeReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>& 
       std::make_shared<datahandlinglibs::SourceEmulatorModel<fdreadoutlibs::types::TDEEthTypeAdapter>>(
         q_id,
         run_marker,
-        tde_time_tick_diff,
-        tde_dropout_rate,
+        tdeeth_time_tick_diff,
+        tdeeth_dropout_rate,
         emu_frame_error_rate,
-        tde_rate_khz,
-        tde_frames_per_tick);
+        tdeeth_rate_khz,
+        tdeeth_frames_per_tick);
     register_node(q_id, source_emu_model);
     return source_emu_model;
   }


### PR DESCRIPTION
Adjusted initialization parameters of the FDFakeCardReader to use parameters from the type adapter classes.