### PR TITLE
Johnfreeman/merge fddaq v5.3.2 rc3 a9 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-cmake/
 
 cmake_minimum_required(VERSION 3.12)
-project(fdreadoutmodules VERSION 2.1.3)
+project(fdreadoutmodules VERSION 2.1.4)
 
 find_package(daq-cmake REQUIRED)
 

--- a/plugins/FDDataHandlerModule.cpp
+++ b/plugins/FDDataHandlerModule.cpp
@@ -33,7 +33,8 @@
 #include "fdreadoutlibs/daphne/DAPHNEStreamFrameProcessor.hpp"
 #include "fdreadoutlibs/wibeth/WIBEthFrameProcessor.hpp"
 #include "fdreadoutlibs/tde/TDEEthFrameProcessor.hpp"
-
+#include "fdreadoutlibs/crt/CRTBernFrameProcessor.hpp"
+#include "fdreadoutlibs/crt/CRTGrenobleFrameProcessor.hpp"
 
 #include <memory>
 #include <sstream>
@@ -48,6 +49,8 @@ DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter, "WIBEt
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter, "PDSFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter, "PDSStreamFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter, "TDEEthFrame")
+DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTBernTypeAdapter, "CRTBernFrame")
+DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTGrenobleTypeAdapter, "CRTGrenobleFrame")
 
 namespace fdreadoutmodules {
 
@@ -107,6 +110,40 @@ FDDataHandlerModule::create_readout(const appmodel::DataHandlerModule* modconf, 
     return readout_model;
   }
   
+  // IF CRTBern
+  if (raw_dt.find("CRTBernFrame") != std::string::npos) {
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for a CRTBern";
+    auto readout_model = std::make_shared<
+      rol::DataHandlingModel<fdt::CRTBernTypeAdapter,
+      rol::ZeroCopyRecordingRequestHandlerModel<
+        fdt::CRTBernTypeAdapter,
+        rol::FixedRateQueueModel<fdt::CRTBernTypeAdapter>
+      >,
+      rol::FixedRateQueueModel<fdt::CRTBernTypeAdapter>,
+      fdl::CRTBernFrameProcessor
+      >>(run_marker);
+    register_node("CRTBernFrameProcessor", readout_model);
+    readout_model->init(modconf);
+    return readout_model;
+  }
+
+  // IF CRTGrenoble
+  if (raw_dt.find("CRTGrenobleFrame") != std::string::npos) {
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for a CRTGrenoble";
+    auto readout_model = std::make_shared<
+      rol::DataHandlingModel<fdt::CRTGrenobleTypeAdapter,
+      rol::ZeroCopyRecordingRequestHandlerModel<
+        fdt::CRTGrenobleTypeAdapter,
+        rol::FixedRateQueueModel<fdt::CRTGrenobleTypeAdapter>
+      >,
+      rol::FixedRateQueueModel<fdt::CRTGrenobleTypeAdapter>,
+      fdl::CRTGrenobleFrameProcessor
+      >>(run_marker);
+    register_node("CRTGrenobleFrameProcessor", readout_model);
+    readout_model->init(modconf);
+    return readout_model;
+  }  
+
   // IF TDEEth
   if (raw_dt.find("TDEEthFrame") != std::string::npos) {
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for an Ethernet TDEEth";


### PR DESCRIPTION
This PR is part of an overall merging of the `patch/fddaq-v5.3.x` branches into `develop` in the wake of release candidate 3 for `fddaq-v5.3.2`; note that the actual source branch, `johnfreeman/merge_fddaq-v5.3.2-rc3-a9_into_develop`, is an intermediary here. A test release was built with the source branch (`NFDT_DEV_250617_A9`) and successful integration tests were run (https://github.com/DUNE-DAQ/daq-release/actions/runs/15717205217). 