### PR TITLE
Use SkipListLatencyBufferModel for CRTs

### DIFF
--- a/plugins/FDDataHandlerModule.cpp
+++ b/plugins/FDDataHandlerModule.cpp
@@ -115,9 +115,8 @@ FDDataHandlerModule::create_readout(const appmodel::DataHandlerModule* modconf, 
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for a CRTBern";
     auto readout_model = std::make_shared<
       rol::DataHandlingModel<fdt::CRTBernTypeAdapter,
-      rol::DefaultRequestHandlerModel<fdt::CRTBernTypeAdapter,
-      rol::BinarySearchQueueModel<fdt::CRTBernTypeAdapter>>,
-      rol::BinarySearchQueueModel<fdt::CRTBernTypeAdapter>,
+      rol::DefaultSkipListRequestHandler<fdt::CRTBernTypeAdapter>,
+      rol::SkipListLatencyBufferModel<fdt::CRTBernTypeAdapter>,
       fdl::CRTBernFrameProcessor
       >>(run_marker);
     register_node("CRTBernFrameProcessor", readout_model);
@@ -130,9 +129,8 @@ FDDataHandlerModule::create_readout(const appmodel::DataHandlerModule* modconf, 
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for a CRTGrenoble";
     auto readout_model = std::make_shared<
       rol::DataHandlingModel<fdt::CRTGrenobleTypeAdapter,
-      rol::DefaultRequestHandlerModel<fdt::CRTGrenobleTypeAdapter,
-      rol::BinarySearchQueueModel<fdt::CRTGrenobleTypeAdapter>>,
-      rol::BinarySearchQueueModel<fdt::CRTGrenobleTypeAdapter>,
+      rol::DefaultSkipListRequestHandler<fdt::CRTGrenobleTypeAdapter>,
+      rol::SkipListLatencyBufferModel<fdt::CRTGrenobleTypeAdapter>,
       fdl::CRTGrenobleFrameProcessor
       >>(run_marker);
     register_node("CRTGrenobleFrameProcessor", readout_model);

--- a/plugins/FDDataHandlerModule.cpp
+++ b/plugins/FDDataHandlerModule.cpp
@@ -115,11 +115,9 @@ FDDataHandlerModule::create_readout(const appmodel::DataHandlerModule* modconf, 
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for a CRTBern";
     auto readout_model = std::make_shared<
       rol::DataHandlingModel<fdt::CRTBernTypeAdapter,
-      rol::ZeroCopyRecordingRequestHandlerModel<
-        fdt::CRTBernTypeAdapter,
-        rol::FixedRateQueueModel<fdt::CRTBernTypeAdapter>
-      >,
-      rol::FixedRateQueueModel<fdt::CRTBernTypeAdapter>,
+      rol::DefaultRequestHandlerModel<fdt::CRTBernTypeAdapter,
+      rol::BinarySearchQueueModel<fdt::CRTBernTypeAdapter>>,
+      rol::BinarySearchQueueModel<fdt::CRTBernTypeAdapter>,
       fdl::CRTBernFrameProcessor
       >>(run_marker);
     register_node("CRTBernFrameProcessor", readout_model);
@@ -132,11 +130,9 @@ FDDataHandlerModule::create_readout(const appmodel::DataHandlerModule* modconf, 
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for a CRTGrenoble";
     auto readout_model = std::make_shared<
       rol::DataHandlingModel<fdt::CRTGrenobleTypeAdapter,
-      rol::ZeroCopyRecordingRequestHandlerModel<
-        fdt::CRTGrenobleTypeAdapter,
-        rol::FixedRateQueueModel<fdt::CRTGrenobleTypeAdapter>
-      >,
-      rol::FixedRateQueueModel<fdt::CRTGrenobleTypeAdapter>,
+      rol::DefaultRequestHandlerModel<fdt::CRTGrenobleTypeAdapter,
+      rol::BinarySearchQueueModel<fdt::CRTGrenobleTypeAdapter>>,
+      rol::BinarySearchQueueModel<fdt::CRTGrenobleTypeAdapter>,
       fdl::CRTGrenobleFrameProcessor
       >>(run_marker);
     register_node("CRTGrenobleFrameProcessor", readout_model);

--- a/plugins/FDFakeReaderModule.cpp
+++ b/plugins/FDFakeReaderModule.cpp
@@ -22,6 +22,8 @@
 #include "fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp"
 #include "fdreadoutlibs/TDEEthTypeAdapter.hpp"
+#include "fdreadoutlibs/CRTBernTypeAdapter.hpp"
+#include "fdreadoutlibs/CRTGrenobleTypeAdapter.hpp"
 
 #include <chrono>
 #include <fstream>
@@ -42,6 +44,8 @@ DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter, "WIBEt
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter, "PDSFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter, "PDSStreamFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter, "TDEEthFrame")
+DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTBernTypeAdapter, "CRTBernFrame")
+DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTGrenobleTypeAdapter, "CRTGrenobleFrame")
 
 namespace fdreadoutmodules {
 
@@ -87,6 +91,16 @@ FDFakeReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>& 
   static constexpr double tdeeth_dropout_rate = 0.0;
   static constexpr double tdeeth_rate_khz = 62500./tdeeth_time_tick_diff;
   static constexpr int tdeeth_frames_per_tick = 1;
+
+  static constexpr int crtbern_time_tick_diff = 625;
+  static constexpr double crtbern_dropout_rate = 0.0;
+  static constexpr double crtbern_rate_khz = 100;
+  static constexpr int crtbern_frames_per_tick = 1;
+
+  static constexpr int crtgrenoble_time_tick_diff = 625;
+  static constexpr double crtgrenoble_dropout_rate = 0.0;
+  static constexpr double crtgrenoble_rate_khz = 100;
+  static constexpr int crtgrenoble_frames_per_tick = 1;  
 
   static constexpr double emu_frame_error_rate = 0.0;
 
@@ -145,6 +159,25 @@ FDFakeReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>& 
     return source_emu_model;
   }
 
+  // IF CRTBern
+  if (raw_dt.find("CRTBernFrame") != std::string::npos) {
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake crt bern link";
+    auto source_emu_model =
+      std::make_shared<datahandlinglibs::SourceEmulatorModel<fdreadoutlibs::types::CRTBernTypeAdapter>>(
+        q_id, run_marker, crtbern_time_tick_diff, crtbern_dropout_rate, emu_frame_error_rate, crtbern_rate_khz, crtbern_frames_per_tick);
+    register_node(q_id, source_emu_model);
+    return source_emu_model;
+  }  
+  
+  // IF CRTGrenoble
+  if (raw_dt.find("CRTGrenobleFrame") != std::string::npos) {
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake crt grenoble link";
+    auto source_emu_model =
+      std::make_shared<datahandlinglibs::SourceEmulatorModel<fdreadoutlibs::types::CRTGrenobleTypeAdapter>>(
+        q_id, run_marker, crtgrenoble_time_tick_diff, crtgrenoble_dropout_rate, emu_frame_error_rate, crtgrenoble_rate_khz, crtgrenoble_frames_per_tick);
+    register_node(q_id, source_emu_model);
+    return source_emu_model;
+  }  
 
   return nullptr;
 }


### PR DESCRIPTION
- Since there isn't a fixed time interval between CRT hits generated by the detectors, `SkipListLatencyBufferModel` should be used instead of `FixedRateQueueModel`. Because; their `lower_bound` functions work differently, leading to `DataRequest`s resulting in `NOT_FOUND`. 
- Make it possible to use `FDFakeReaderModule` with CRT frames

Relevant: [Use BinarySearchQueueModel for CRTs #273](https://github.com/DUNE-DAQ/fdreadoutlibs/pull/273)

The following is the list of relevant branches (where `SkipListLatencyBufferModel` is used as the buffer type):
asiolibs: dte/asio_integtest
daqsystemtest: dte/emu_crt
appmodel: dte/fakereader_crt
fdreadoutlibs: dte/queue_for_crt
fdreadoutmodules: dte/queue_for_crt
crtmodules: dte/crt_integtest