### PR TITLE
DAPHNE Ethernet support

### DIFF
--- a/plugins/DataRecorderModule.cpp
+++ b/plugins/DataRecorderModule.cpp
@@ -77,7 +77,7 @@ DataRecorderModule::init(const data_t& args)
     }
 
     // IF PDSEth
-    if (raw_dt.find("PDSEthFrame") != std::string::npos) {
+    if (raw_dt.find("DAPHNEEthFrame") != std::string::npos) {
       TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating recorder for pds";
       recorder.reset(new datahandlinglibs::RecorderModel<fdreadoutlibs::types::DAPHNEEthTypeAdapter>(get_name()));
       recorder->init(args);

--- a/plugins/DataRecorderModule.cpp
+++ b/plugins/DataRecorderModule.cpp
@@ -9,6 +9,7 @@
 #include "fdreadoutlibs/DUNEWIBEthTypeAdapter.hpp"
 #include "fdreadoutlibs/TDEEthFrameTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp"
+#include "fdreadoutlibs/DAPHNEEthTypeAdapter.hpp"
 
 #include "datahandlinglibs/ReadoutLogging.hpp"
 #include "datahandlinglibs/models/RecorderModel.hpp"
@@ -71,6 +72,14 @@ DataRecorderModule::init(const data_t& args)
     if (raw_dt.find("PDSFrame") != std::string::npos) {
       TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating recorder for pds";
       recorder.reset(new datahandlinglibs::RecorderModel<fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>(get_name()));
+      recorder->init(args);
+      return;
+    }
+
+    // IF PDSEth
+    if (raw_dt.find("PDSEthFrame") != std::string::npos) {
+      TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating recorder for pds";
+      recorder.reset(new datahandlinglibs::RecorderModel<fdreadoutlibs::types::DAPHNEEthTypeAdapter>(get_name()));
       recorder->init(args);
       return;
     }

--- a/plugins/FDDataHandlerModule.cpp
+++ b/plugins/FDDataHandlerModule.cpp
@@ -53,7 +53,7 @@ DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAda
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter, "TDEEthFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTBernTypeAdapter, "CRTBernFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTGrenobleTypeAdapter, "CRTGrenobleFrame")
-DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEEthTypeAdapter, "PDSEthFrame")
+DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEEthTypeAdapter, "DAPHNEEthFrame")
 
 namespace fdreadoutmodules {
 
@@ -173,14 +173,14 @@ FDDataHandlerModule::create_readout(const appmodel::DataHandlerModule* modconf, 
   }
 
   // IF PDS Frame using skiplist
-  if (raw_dt.find("PDSEthFrame") != std::string::npos) {
+  if (raw_dt.find("DAPHNEEthFrame") != std::string::npos) {
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for a PDS DAPHNE Ethernet using SkipList LB";
     auto readout_model = std::make_shared<rol::DataHandlingModel<
         fdt::DAPHNEEthTypeAdapter,
         rol::DefaultSkipListRequestHandler<fdt::DAPHNEEthTypeAdapter>,
         rol::SkipListLatencyBufferModel<fdt::DAPHNEEthTypeAdapter>,
         fdl::DAPHNEEthFrameProcessor>>(run_marker);
-    register_node("PDSEthFrameProcessor", readout_model);
+    register_node("DAPHNEEthFrameProcessor", readout_model);
     readout_model->init(modconf);
     return readout_model;
   }

--- a/plugins/FDDataHandlerModule.cpp
+++ b/plugins/FDDataHandlerModule.cpp
@@ -28,6 +28,7 @@
 #include "fdreadoutlibs/DAPHNESuperChunkTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp"
 #include "fdreadoutlibs/TDEEthTypeAdapter.hpp"
+#include "fdreadoutlibs/DAPHNEEthTypeAdapter.hpp"
 
 #include "fdreadoutlibs/daphne/DAPHNEFrameProcessor.hpp"
 #include "fdreadoutlibs/daphne/DAPHNEStreamFrameProcessor.hpp"
@@ -35,6 +36,7 @@
 #include "fdreadoutlibs/tde/TDEEthFrameProcessor.hpp"
 #include "fdreadoutlibs/crt/CRTBernFrameProcessor.hpp"
 #include "fdreadoutlibs/crt/CRTGrenobleFrameProcessor.hpp"
+#include "fdreadoutlibs/daphneeth/DAPHNEEthFrameProcessor.hpp"
 
 #include <memory>
 #include <sstream>
@@ -51,6 +53,7 @@ DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAda
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter, "TDEEthFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTBernTypeAdapter, "CRTBernFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTGrenobleTypeAdapter, "CRTGrenobleFrame")
+DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEEthTypeAdapter, "PDSEthFrame")
 
 namespace fdreadoutmodules {
 
@@ -165,6 +168,19 @@ FDDataHandlerModule::create_readout(const appmodel::DataHandlerModule* modconf, 
         rol::SkipListLatencyBufferModel<fdt::DAPHNESuperChunkTypeAdapter>,
         fdl::DAPHNEFrameProcessor>>(run_marker);
     register_node("PDSFrameProcessor", readout_model);
+    readout_model->init(modconf);
+    return readout_model;
+  }
+
+  // IF PDS Frame using skiplist
+  if (raw_dt.find("PDSEthFrame") != std::string::npos) {
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for a PDS DAPHNE Ethernet using SkipList LB";
+    auto readout_model = std::make_shared<rol::DataHandlingModel<
+        fdt::DAPHNEEthTypeAdapter,
+        rol::DefaultSkipListRequestHandler<fdt::DAPHNEEthTypeAdapter>,
+        rol::SkipListLatencyBufferModel<fdt::DAPHNEEthTypeAdapter>,
+        fdl::DAPHNEEthFrameProcessor>>(run_marker);
+    register_node("PDSEthFrameProcessor", readout_model);
     readout_model->init(modconf);
     return readout_model;
   }

--- a/plugins/FDFakeReaderModule.cpp
+++ b/plugins/FDFakeReaderModule.cpp
@@ -24,6 +24,7 @@
 #include "fdreadoutlibs/TDEEthTypeAdapter.hpp"
 #include "fdreadoutlibs/CRTBernTypeAdapter.hpp"
 #include "fdreadoutlibs/CRTGrenobleTypeAdapter.hpp"
+#include "fdreadoutlibs/DAPHNEEthTypeAdapter.hpp"
 
 #include <chrono>
 #include <fstream>
@@ -43,6 +44,7 @@ namespace dunedaq {
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter, "WIBEthFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter, "PDSFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter, "PDSStreamFrame")
+DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEEthTypeAdapter, "PDSEthFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter, "TDEEthFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTBernTypeAdapter, "CRTBernFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTGrenobleTypeAdapter, "CRTGrenobleFrame")
@@ -81,6 +83,11 @@ FDFakeReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>& 
   static constexpr double daphne_dropout_rate = 0.0;
   static constexpr double daphne_rate_khz = 62500./daphne_time_tick_diff/fdreadoutlibs::types::kDAPHNENumFrames;
   static constexpr int daphne_frames_per_tick = 1;
+
+  static constexpr int daphneeth_time_tick_diff = fdreadoutlibs::types::DAPHNEEthTypeAdapter::expected_tick_difference;
+  static constexpr double daphneeth_dropout_rate = 0.0;
+  static constexpr double daphneeth_rate_khz = 62500./daphneeth_time_tick_diff;
+  static constexpr int daphneeth_frames_per_tick = 1;
 
   static constexpr int wibeth_time_tick_diff = fdreadoutlibs::types::DUNEWIBEthTypeAdapter::expected_tick_difference;;
   static constexpr double wibeth_dropout_rate = 0.0;
@@ -129,6 +136,16 @@ FDFakeReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>& 
     auto source_emu_model =
       std::make_shared<datahandlinglibs::SourceEmulatorModel<fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter>>(
         q_id, run_marker, daphne_time_tick_diff, daphne_dropout_rate, emu_frame_error_rate, daphne_rate_khz, daphne_frames_per_tick);
+      register_node(q_id, source_emu_model);
+      return source_emu_model;
+  }
+
+  // IF PDS Ethernet
+  if (raw_dt.find("PDSEthFrame") != std::string::npos) {
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake pds link";
+    auto source_emu_model =
+      std::make_shared<datahandlinglibs::SourceEmulatorModel<fdreadoutlibs::types::DAPHNEEthTypeAdapter>>(
+        q_id, run_marker, daphneeth_time_tick_diff, daphneeth_dropout_rate, emu_frame_error_rate, daphneeth_rate_khz, daphneeth_frames_per_tick);
       register_node(q_id, source_emu_model);
       return source_emu_model;
   }

--- a/plugins/FDFakeReaderModule.cpp
+++ b/plugins/FDFakeReaderModule.cpp
@@ -44,7 +44,7 @@ namespace dunedaq {
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DUNEWIBEthTypeAdapter, "WIBEthFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNESuperChunkTypeAdapter, "PDSFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter, "PDSStreamFrame")
-DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEEthTypeAdapter, "PDSEthFrame")
+DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEEthTypeAdapter, "DAPHNEEthFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter, "TDEEthFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTBernTypeAdapter, "CRTBernFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTGrenobleTypeAdapter, "CRTGrenobleFrame")
@@ -141,7 +141,7 @@ FDFakeReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>& 
   }
 
   // IF PDS Ethernet
-  if (raw_dt.find("PDSEthFrame") != std::string::npos) {
+  if (raw_dt.find("DAPHNEEthFrame") != std::string::npos) {
     TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake pds link";
     auto source_emu_model =
       std::make_shared<datahandlinglibs::SourceEmulatorModel<fdreadoutlibs::types::DAPHNEEthTypeAdapter>>(


### PR DESCRIPTION
This PR adds the DAPHNE Ethernet data handler configuration to FD datahandling modules.
Parent issue: https://github.com/DUNE-DAQ/fdreadoutmodules/issues/57