### PR TITLE
Johnfreeman/prep release merged

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 # https://dune-daq-sw.readthedocs.io/en/latest/packages/daq-cmake/
 
 cmake_minimum_required(VERSION 3.12)
-project(fdreadoutmodules VERSION 2.1.6)
+project(fdreadoutmodules VERSION 2.2.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/plugins/FDDataHandlerModule.cpp
+++ b/plugins/FDDataHandlerModule.cpp
@@ -29,6 +29,7 @@
 #include "fdreadoutlibs/DAPHNEStreamSuperChunkTypeAdapter.hpp"
 #include "fdreadoutlibs/TDEEthTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNEEthTypeAdapter.hpp"
+#include "fdreadoutlibs/DAPHNEEthStreamTypeAdapter.hpp"
 
 #include "fdreadoutlibs/daphne/DAPHNEFrameProcessor.hpp"
 #include "fdreadoutlibs/daphne/DAPHNEStreamFrameProcessor.hpp"
@@ -37,6 +38,7 @@
 #include "fdreadoutlibs/crt/CRTBernFrameProcessor.hpp"
 #include "fdreadoutlibs/crt/CRTGrenobleFrameProcessor.hpp"
 #include "fdreadoutlibs/daphneeth/DAPHNEEthFrameProcessor.hpp"
+#include "fdreadoutlibs/daphneeth/DAPHNEEthStreamFrameProcessor.hpp"
 
 #include <memory>
 #include <sstream>
@@ -54,6 +56,7 @@ DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::TDEEthTypeAdapter, "TDEEthFra
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTBernTypeAdapter, "CRTBernFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::CRTGrenobleTypeAdapter, "CRTGrenobleFrame")
 DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEEthTypeAdapter, "DAPHNEEthFrame")
+DUNE_DAQ_TYPESTRING(dunedaq::fdreadoutlibs::types::DAPHNEEthStreamTypeAdapter, "DAPHNEEthStreamFrame")
 
 namespace fdreadoutmodules {
 
@@ -199,6 +202,19 @@ FDDataHandlerModule::create_readout(const appmodel::DataHandlerModule* modconf, 
     return readout_model;
   }
 
+  // IF PDS Stream Frame using SPSC LB
+  if (raw_dt.find("DAPHNEEthStreamFrame") != std::string::npos) {
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating readout for a DAPHNE eth stream mode using BinarySearchQueue LB";
+    auto readout_model = std::make_shared<
+      rol::DataHandlingModel<fdt::DAPHNEEthStreamTypeAdapter,
+                        rol::DefaultRequestHandlerModel<fdt::DAPHNEEthStreamTypeAdapter,
+                        rol::BinarySearchQueueModel<fdt::DAPHNEEthStreamTypeAdapter>>,
+                        rol::BinarySearchQueueModel<fdt::DAPHNEEthStreamTypeAdapter>,
+                        fdl::DAPHNEEthStreamFrameProcessor>>(run_marker);
+    register_node("DAPHNEEthStreamFrameProcessor", readout_model);
+    readout_model->init(modconf);
+    return readout_model;
+  }
   return nullptr;
 }
 

--- a/plugins/FDFakeReaderModule.cpp
+++ b/plugins/FDFakeReaderModule.cpp
@@ -25,6 +25,7 @@
 #include "fdreadoutlibs/CRTBernTypeAdapter.hpp"
 #include "fdreadoutlibs/CRTGrenobleTypeAdapter.hpp"
 #include "fdreadoutlibs/DAPHNEEthTypeAdapter.hpp"
+#include "fdreadoutlibs/DAPHNEEthStreamTypeAdapter.hpp"
 
 #include <chrono>
 #include <fstream>
@@ -88,6 +89,11 @@ FDFakeReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>& 
   static constexpr double daphneeth_dropout_rate = 0.0;
   static constexpr double daphneeth_rate_khz = 62500./daphneeth_time_tick_diff;
   static constexpr int daphneeth_frames_per_tick = 1;
+
+  static constexpr int daphneethstream_time_tick_diff = fdreadoutlibs::types::DAPHNEEthStreamTypeAdapter::expected_tick_difference;
+  static constexpr double daphneethstream_dropout_rate = 0.0;
+  static constexpr double daphneethstream_rate_khz = 62500./daphneethstream_time_tick_diff/fdreadoutlibs::types::kDAPHNEEthStreamNumFrames;
+  static constexpr int daphneethstream_frames_per_tick = 1;
 
   static constexpr int wibeth_time_tick_diff = fdreadoutlibs::types::DUNEWIBEthTypeAdapter::expected_tick_difference;;
   static constexpr double wibeth_dropout_rate = 0.0;
@@ -156,6 +162,16 @@ FDFakeReaderModule::create_source_emulator(std::string q_id, std::atomic<bool>& 
     auto source_emu_model =
       std::make_shared<datahandlinglibs::SourceEmulatorModel<fdreadoutlibs::types::DAPHNEStreamSuperChunkTypeAdapter>>(
         q_id, run_marker, daphnestream_time_tick_diff, daphnestream_dropout_rate, emu_frame_error_rate, daphnestream_rate_khz, daphnestream_frames_per_tick);
+      register_node(q_id, source_emu_model);
+    return source_emu_model;
+  }
+
+  // IF PDS Eth Stream
+  if (raw_dt.find("DAPHNEEthStreamFrame") != std::string::npos) {
+    TLOG_DEBUG(TLVL_WORK_STEPS) << "Creating fake pds stream link";
+    auto source_emu_model =
+      std::make_shared<datahandlinglibs::SourceEmulatorModel<fdreadoutlibs::types::DAPHNEEthStreamTypeAdapter>>(
+        q_id, run_marker, daphneethstream_time_tick_diff, daphneethstream_dropout_rate, emu_frame_error_rate, daphneethstream_rate_khz, daphneethstream_frames_per_tick);
       register_node(q_id, source_emu_model);
     return source_emu_model;
   }


### PR DESCRIPTION
With `fddaq-v5.5.0` now cut, this source branch consists of a fork of the `develop` branch with `prep-release/fddaq-v5.5.0` merged in (i.e., this will be a fast-forward merge which brings the `fddaq-v5.5.0` code into `develop`). Over the weekend a test nightly was created, `MRGFD_DEV_251213_A9`, in which all the `johnfreeman/prep_release_merged` branches were used, and if I `pip install -U . ` the `johnfreeman/prep_release_merged` branch of `drunc`, integration tests with it look fine. 

# Description

_If full decription and testing details are included on a parent issue, please link to that here._
See issue # for details

_Otherwise, please include a summary of the change and which issue is fixed (if any).
Include relevant motivation and context, including a target environment and dunedaq version if known.
Also list any dependencies that are required for this change._
Addresses issue # 

_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

