### PR TITLE
Lowered CRT emulation rates to 10 kHz

### DIFF
--- a/plugins/FDFakeReaderModule.cpp
+++ b/plugins/FDFakeReaderModule.cpp
@@ -105,14 +105,14 @@ FDFakeReaderModule::create_source_emulator(const appmodel::DataMoveCallbackConf*
   static constexpr double tdeeth_rate_khz = 62500./tdeeth_time_tick_diff;
   static constexpr int tdeeth_frames_per_tick = 1;
 
-  static constexpr int crtbern_time_tick_diff = 625;
+  static constexpr int crtbern_time_tick_diff = 2500;
   static constexpr double crtbern_dropout_rate = 0.0;
-  static constexpr double crtbern_rate_khz = 10;
+  static constexpr double crtbern_rate_khz = 25;
   static constexpr int crtbern_frames_per_tick = 1;
 
-  static constexpr int crtgrenoble_time_tick_diff = 625;
+  static constexpr int crtgrenoble_time_tick_diff = 2500;
   static constexpr double crtgrenoble_dropout_rate = 0.0;
-  static constexpr double crtgrenoble_rate_khz = 10;
+  static constexpr double crtgrenoble_rate_khz = 25;
   static constexpr int crtgrenoble_frames_per_tick = 1;
 
   static constexpr double emu_frame_error_rate = 0.0;

--- a/plugins/FDFakeReaderModule.cpp
+++ b/plugins/FDFakeReaderModule.cpp
@@ -107,12 +107,12 @@ FDFakeReaderModule::create_source_emulator(const appmodel::DataMoveCallbackConf*
 
   static constexpr int crtbern_time_tick_diff = 625;
   static constexpr double crtbern_dropout_rate = 0.0;
-  static constexpr double crtbern_rate_khz = 100;
+  static constexpr double crtbern_rate_khz = 10;
   static constexpr int crtbern_frames_per_tick = 1;
 
   static constexpr int crtgrenoble_time_tick_diff = 625;
   static constexpr double crtgrenoble_dropout_rate = 0.0;
-  static constexpr double crtgrenoble_rate_khz = 100;
+  static constexpr double crtgrenoble_rate_khz = 10;
   static constexpr int crtgrenoble_frames_per_tick = 1;
 
   static constexpr double emu_frame_error_rate = 0.0;


### PR DESCRIPTION
...since the real CRT readers use this rate and otherwise the integration test fails with request timeouts.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)
