### PR TITLE
Modified a few of the CRT-related parameters in FDFakeReaderModule.cpp…

### DIFF
--- a/plugins/FDFakeReaderModule.cpp
+++ b/plugins/FDFakeReaderModule.cpp
@@ -105,14 +105,14 @@ FDFakeReaderModule::create_source_emulator(const appmodel::DataMoveCallbackConf*
   static constexpr double tdeeth_rate_khz = 62500./tdeeth_time_tick_diff;
   static constexpr int tdeeth_frames_per_tick = 1;
 
-  static constexpr int crtbern_time_tick_diff = 625;
+  static constexpr int crtbern_time_tick_diff = 2500;
   static constexpr double crtbern_dropout_rate = 0.0;
-  static constexpr double crtbern_rate_khz = 10;
+  static constexpr double crtbern_rate_khz = 25;
   static constexpr int crtbern_frames_per_tick = 1;
 
-  static constexpr int crtgrenoble_time_tick_diff = 625;
+  static constexpr int crtgrenoble_time_tick_diff = 2500;
   static constexpr double crtgrenoble_dropout_rate = 0.0;
-  static constexpr double crtgrenoble_rate_khz = 10;
+  static constexpr double crtgrenoble_rate_khz = 25;
   static constexpr int crtgrenoble_frames_per_tick = 1;
 
   static constexpr double emu_frame_error_rate = 0.0;


### PR DESCRIPTION
…so that the packet rate isn't too high, and the rate times the tick difference is still 62500000.

# Description

Please note that the target branch for these changes is `dte/crt_rates` since I started with that branch.

The goal of these changes (and related ones in `asiolibs`) is to get the `socket_reader_test.py` integtest in the `asiolibs` repo working.

My theory is that the TimestampEstimator does not handle multiple sources of TimeSync messages at high rates (e.g. 100 kHz), and that was what we were asking it to do with the initial "crt topology" changes.  Lowering the packet rate by a factor of 4 (to 25 kHz) while increasing the `time_tick_diff`by a factor of 4 (to 2500 ticks) keeps the overall product of rate times time_tick_diff at 62,500,000 (which is important for providing TimeSync messages that track fairly well with real wallclock time).

To test these changes, I suggest using a software area based on a recently nightly and adding the following repos with the specified branches.  

```
appmodel: dte/crt_topology_change [d344896]
asiolibs: kbiery/integtest_small_mods [472cd32]
crtmodules: dte/crt_topology_change* [815c702]
daqconf: dte/crt_cb_update [79c5f71]
daqsystemtest: dte/crt_topology_change* [b125aeb]
datahandlinglibs: dte/cb_acquire [52010b5]
dfmodules: develop [c1af62d]
fddetdataformats: develop [7c2117d]
fdreadoutlibs: develop [1d9753c]
fdreadoutmodules: kbiery/crt_fake_param_mods [8bd85fe]
hsilibs: develop [21d3b82]
trigger: develop [3b5e6dc]
utilities: develop [65a37c3]
```

With these branches, I see that the `asiolibs/socket_reader_test` and the `crtmodules/crt_reader_test` run successfully.

## Type of change

- [x] Optimization (non-breaking change that improves code/performance)

## Testing checklist

- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
